### PR TITLE
Provide 72-hour deadline when notifying users

### DIFF
--- a/main.go
+++ b/main.go
@@ -153,6 +153,9 @@ func main() {
 	}
 	log.Printf("PPL: -- %+v -- ", ppl)
 
+	// Provide a date string for three days in the future
+	threeDays := time.Now().AddDate(0, 0, 3).Format(time.RFC850)
+
 	for _, info := range ppl {
 		// Instructions to be populated based on the user's onboarding status
 		needs := []string{}
@@ -163,9 +166,11 @@ func main() {
 			needs = append(needs, `✅ Accept our latest policies at https://app.secureframe.com/onboard/employee/policies`)
 			needs = append(needs, `🏋️‍♀️ Take Cybersecurity training at {{.SecurityTrainingURL}}`)
 			needs = append(needs, `⬆️ Upload proof of completion to https://app.secureframe.com/onboard/employee/training (PDF or screenshot)`)
+			needs = append(needs, fmt.Sprintf(`📆 Accept policies and upload proof within 72 hours of receiving this notification (by %s)`, threeDays))
 		case "security_training":
 			needs = append(needs, `🏋️‍♀️ Take Cybersecurity training at {{.SecurityTrainingURL}}`)
 			needs = append(needs, `⬆️ Upload proof of completion to https://app.secureframe.com/onboard/employee/training (PDF or screenshot)`)
+			needs = append(needs, fmt.Sprintf(`📆 Upload proof within 72 hours of receiving this notification (by %s)`, threeDays))
 		default:
 			continue
 		}


### PR DESCRIPTION
This is a smaller alternative for #5 -- we'll provide a 72-hour deadline (with accompanying date string) for users to let them know the deadline for accepting their policies and/or uploading their proof of completion.

Example:
```
I am ComplyBot3000 🤖, your _Policy Compliance Pal Who's Fun To Be With©_. My job is to keep  conformant to the compliance frameworks that our customers require of us, such as SOC-2 and ISO 27001. Based on my records, I need your help with:

• ✅ Accept our latest policies at https://app.secureframe.com/onboard/employee/policies
• 🏋️‍♀️ Take Cybersecurity training at https://securityawareness.usalearning.gov/cybersecurity/index.htm
• ⬆️ Upload proof of completion to https://app.secureframe.com/onboard/employee/training (PDF or screenshot)
• 📆 Accept policies and upload proof within 72 hours of receiving this notification (by Friday, 04-Oct-24 11:07:11 CDT)

These items will need to be refreshed annually. Thank you for keeping  🔥! If you have questions, you can find my creators in #security-and-compliance.
```